### PR TITLE
Add Gnome 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
   "name": "Boost Volume",
   "description": "Boosts volume above limits",
   "uuid": "boostvolume@shaquib.dev",
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "url": "https://github.com/shaquibimdad/gnome_ext_volume_boost"
 }


### PR DESCRIPTION
Just adding the 49 version in `metadata.json`. I tested it on gnome 49 arch and it seems to work without issues.